### PR TITLE
Fixed line break

### DIFF
--- a/TEMPLATE_MODULE_README.md
+++ b/TEMPLATE_MODULE_README.md
@@ -5,6 +5,7 @@ Module description.
 ## Credits and References
 
 Author: 
+
 Operating System(s): 
 
 Additional credits and references:

--- a/aws/README.md
+++ b/aws/README.md
@@ -5,6 +5,7 @@ The AWS module assumes the AWS CLI is pre-installed on the system. Use this modu
 ## Credits and References
 
 Author: SCYTHE
+
 Operating System(s): Windows
 
 ## Installation

--- a/azure/README.md
+++ b/azure/README.md
@@ -5,6 +5,7 @@ This Azure module assumes the Azure CLI is pre-installed on the system and provi
 ## Credits and References
 
 Author: SCYTHE
+
 Operating System(s): Windows
 
 ## Installation

--- a/chrome_cracker/README.md
+++ b/chrome_cracker/README.md
@@ -5,6 +5,7 @@ Chrome Cracker nicknamed DeSpell, is a password cracker for Google Chromes local
 ## Credits and References
 
 Author: SCYTHE
+
 Operating System(s): Windows
 
 Additional credits and references:

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -5,6 +5,7 @@ Enumerate member permissions, retrieve access token, or issue CLI commands. Assu
 ## Credits and References
 
 Author: SCYTHE
+
 Operating System(s): Windows
 
 ## Installation

--- a/health_inspector/README.md
+++ b/health_inspector/README.md
@@ -5,6 +5,7 @@ Performs host recon on a macOs target.
 ## Credits and References
 
 Author: Cody Thomas, SCYTHE / ProServe
+
 Operating System(s): macOS
 
 Additional credits and references:

--- a/jxa_loader/README.md
+++ b/jxa_loader/README.md
@@ -5,6 +5,7 @@ Execute arbitrary JavaScript for Automation on a macOS target.
 ## Credits and References
 
 Author: SCYTHE / ProServe
+
 Operating System(s): MacOS
 
 ## Installation

--- a/kerberoast/README.md
+++ b/kerberoast/README.md
@@ -5,6 +5,7 @@ This modules identifies executes the Kerberoast attack based on the work of Tim 
 ## Credits and References
 
 Author: Tim Medin / RedSiege 
+
 Operating System(s): Windows
 
 ## Installation

--- a/lns/README.md
+++ b/lns/README.md
@@ -5,6 +5,7 @@ LNS is a native Scythe module written in C that performs simple TCP connect scan
 ## Credits and References
 
 Author: GRIMM
+
 Operating System(s): Windows
 
 ## Installation

--- a/orchard/README.md
+++ b/orchard/README.md
@@ -5,6 +5,7 @@ Perform Active Directory enumeration and recon from a macOS Target.
 ## Credits and References
 
 Author: Cody Thomas, SCYTHE / ProServe
+
 Operating System(s): MacOS
 
 Additional credits and references:

--- a/processhollowing/README.md
+++ b/processhollowing/README.md
@@ -5,6 +5,7 @@ The Process Hollowing module replaces a target process with a new executable ima
 ## Credits and References
 
 Author: SCYTHE
+
 Operating System(s): Windows
 
 ## Installation

--- a/proclist/README.md
+++ b/proclist/README.md
@@ -5,6 +5,7 @@ List Processes running on an implant. Filter by User, PID, and PPID for Linux an
 ## Credits and References
 
 Author: SCYTHE/ProServe
+
 Operating System(s): Linux, MacOS
 
 Additional credits and references:

--- a/simple_process_injection/README.md
+++ b/simple_process_injection/README.md
@@ -5,6 +5,7 @@ Performs a simple remote process injection of 64-bit shellcode. Windows calc.exe
 ## Credits and References
 
 Author: Joff Thyer
+
 Operating System(s): Windows
 
 ## Installation

--- a/test_lmo/README.md
+++ b/test_lmo/README.md
@@ -5,6 +5,7 @@ A macOS port to test connectivity and firewall rules for outbound connections fr
 ## Credits and References
 
 Author: SCYTHE / ProServe
+
 Operating System(s): MacOS
 
 Additional credits and references:

--- a/ubash/README.md
+++ b/ubash/README.md
@@ -5,6 +5,7 @@ Run unmanaged `bash` and `shell` scripts from memory without invoking `bash -c`.
 ## Credits and References
 
 Author: SCYTHE / ProServe
+
 Operating System(s): Linux
 
 ## Installation

--- a/yarascan/Readme.md
+++ b/yarascan/Readme.md
@@ -5,6 +5,7 @@ The Yarascan module allows users to scan files and directories with Yara rules.
 ## Credits and References
 
 Author: SCYTHE
+
 Operating System(s): Windows
 
 ## Installation


### PR DESCRIPTION
Fixed the line break between Author and Operating System. In GitHub's Markdown format you need an empty line between two lines/paragraphs to space them out.